### PR TITLE
add new flag to print launch ui url

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ If you like to override some of parameters above from command line, or from CI e
 
 `--rp-launch-description` to change description of a launch
 
-`--ignore-loggers` tto ignore external loggers and not send them in report portal. Specify which statements to filter. If the output is too verbose, use this option to filter out needless output.
+`--ignore-loggers` to ignore external loggers and not send them in report portal. Specify which statements to filter. If the output is too verbose, use this option to filter out needless output.
+
+`--rp-log-launch-id` to print launch ui url when finalize. Default value is `False`.
 
 Example:
 

--- a/nose_reportportal/plugin.py
+++ b/nose_reportportal/plugin.py
@@ -116,6 +116,14 @@ class ReportPortalPlugin(Plugin):
             help="logger filter",
         )
 
+        parser.add_option(
+            "--rp-log-launch-id",
+            action="store_true",
+            dest="log_launch_id",
+            default=False,
+            help="log lauch id after sent all report output",
+        )
+
     def configure(self, options, conf):
         """
         Configure plugin.
@@ -157,6 +165,8 @@ class ReportPortalPlugin(Plugin):
                 if options.rp_mode in ("DEFAULT", "DEBUG")
                 else "DEFAULT"
             )
+
+            self.log_launch_id = options.log_launch_id
 
             if options.ignore_loggers and isinstance(
                 options.ignore_loggers, basestring
@@ -261,6 +271,9 @@ class ReportPortalPlugin(Plugin):
 
         # Finish launch.
         self.service.finish_launch()
+
+        if(self.log_launch_id):
+            print('Launch ID ReportPortal: {}'.format(self.service.rp.get_launch_ui_url()))
 
         # Due to async nature of the service we need to call terminate() method which
         # ensures all pending requests to server are processed.


### PR DESCRIPTION
Adds a new flag (`--rp-log-launch-id`) to allow logging the launch url after tests run.

Example:
`nosetests --with-reportportal --rp-config-file rp.ini --rp-log-launch-id`
Result will be printed like:
`Launch ID ReportPortal: http://host/ui/#project_name/launches/all/id`
